### PR TITLE
Preload fade in

### DIFF
--- a/demo/index-cover.html
+++ b/demo/index-cover.html
@@ -55,7 +55,8 @@
             <template>
                 <style is="custom-style">
                     #cover-2 {
-                        width: 100%;
+                        width: 300px;
+                        height: 300px;
                     }
                 </style>
                 <kwc-share-cover id="cover-2"></kwc-share-cover>
@@ -66,12 +67,35 @@
             </template>
         </demo-snippet>
 
+        <h3>Custom kwc-share-cover</h3>
+        <demo-snippet>
+            <template>
+                <style is="custom-style">
+                    #cover-custom {
+                        width: 300px;
+                        height: 300px;
+                        --kwc-share-cover-placeholder: red;
+                    }
+                </style>
+                <kwc-share-cover
+                    id="cover-custom"
+                    sizing="cover"
+                    fallback-url="https://goo.gl/GA2cEF">
+                </kwc-share-cover>
+                <script type="text/javascript">
+                    shareCover = document.querySelector('#cover-custom');
+                    shareCover.imageUrl = '//kano.me/broken-url.png';
+                </script>
+            </template>
+        </demo-snippet>
+
         <h3>Sound sample kwc-share-cover</h3>
         <demo-snippet>
             <template>
                 <style is="custom-style">
                     #cover-3 {
-                        width: 100%;
+                        width: 300px;
+                        height: 150px;
                     }
                 </style>
                 <kwc-share-cover id="cover-3"></kwc-share-cover>
@@ -87,7 +111,8 @@
             <template>
                 <style is="custom-style">
                     #cover-4 {
-                        width: 100%;
+                        width: 300px;
+                        height: 300px;
                     }
                 </style>
                 <kwc-share-cover id="cover-4"></kwc-share-cover>
@@ -108,16 +133,33 @@
                     }
                     kwc-share-cover.small {
                         width: 172px;
+                        height: 86px;
                         max-height: 86px;
                         overflow: hidden;
                         margin: 2px;
                     }
                 </style>
                 <div class="wrapper">
-                    <kwc-share-cover class="small" id="cover-5"></kwc-share-cover>
-                    <kwc-share-cover class="small" id="cover-6"></kwc-share-cover>
-                    <kwc-share-cover class="small" id="cover-7"></kwc-share-cover>
-                    <kwc-share-cover class="small" id="cover-8"></kwc-share-cover>
+                    <kwc-share-cover
+                        class="small"
+                        id="cover-5"
+                        fallback-url="https://goo.gl/GA2cEF">
+                    </kwc-share-cover>
+                    <kwc-share-cover
+                        class="small"
+                        id="cover-6"
+                        fallback-url="https://goo.gl/GA2cEF">
+                    </kwc-share-cover>
+                    <kwc-share-cover
+                        class="small"
+                        id="cover-7"
+                        fallback-url="https://goo.gl/GA2cEF">
+                    </kwc-share-cover>
+                    <kwc-share-cover
+                        class="small"
+                        id="cover-8"
+                        fallback-url="https://goo.gl/GA2cEF">
+                    </kwc-share-cover>
                 </div>
                 <script type="text/javascript">
                     document.querySelector('#cover-5').imageUrl = SHARES[0].imageUrl;

--- a/kwc-share-cover.html
+++ b/kwc-share-cover.html
@@ -20,6 +20,7 @@ Renders an appropriate cover for any share.
             }
             .share-card-cover {
                 width: 100%;
+                height: 100%;
             }
             .share-cover-spritesheet,
             .share-cover-image {
@@ -28,6 +29,12 @@ Renders an appropriate cover for any share.
             }
             .share-cover-image {
                 @apply --kwc-share-cover-image;
+                flex: 1;
+                width: 100%;
+                height: 100%;
+                --iron-image-placeholder: {
+                    background: var(--kwc-share-cover-placeholder, lightgrey);
+                }
             }
             .share-cover-spritesheet {
                 @apply --kwc-share-cover-spritesheet;
@@ -41,7 +48,14 @@ Renders an appropriate cover for any share.
                 </kwc-lightboard-preview>
             </template>
             <template is="dom-if" if="[[!spritesheetUrl]]">
-                <img class="share-cover-image" src="[[imageUrl]]" />
+                <iron-image
+                    preload
+                    fade
+                    class="share-cover-image"
+                    src="[[_imageUrl]]"
+                    sizing="[[sizing]]"
+                    on-error-changed="imageError">
+                </iron-image>
             </template>
         </div>
     </template>
@@ -56,7 +70,8 @@ Renders an appropriate cover for any share.
                  */
                 imageUrl: {
                     type: String,
-                    value: null
+                    value: null,
+                    observer: '_imageUrlChanged'
                 },
                 /**
                  * URL of a lightboard spritesheet.
@@ -66,9 +81,28 @@ Renders an appropriate cover for any share.
                  */
                 spritesheetUrl: {
                     type: String,
-                    value: null
+                    value: null,
+                },
+                sizing: {
+                    type: String,
+                    value: 'contain',
+                },
+                fallbackUrl: {
+                    type: String,
+                    value: null,
                 }
-            }
+            },
+            _imageUrlChanged: function(image) {
+                this.set('_imageUrl', image)
+            },
+            imageError: function(event, par) {
+                const imageError = par.value;
+                const fallback = this.fallback;
+
+                if (imageError && fallback !== null) {
+                    this.set('_imageUrl', this.fallbackUrl);
+                }
+            },
         });
     </script>
 </dom-module>


### PR DESCRIPTION
For the fallback image I saw this:

https://github.com/PolymerElements/iron-image/pull/44/files/c87d9febfc7a83cc9c75c6228211b0514e13873a#diff-3005a2eaefe34d5d0afb8d08687f8aae

We can maybe listen for the `error-changed` event and decide to change the image with a fallback image.

What do you think @paulvarache ?